### PR TITLE
Saem reworking nimsuggest launch

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,5 +11,6 @@
     "editor.insertSpaces": true,
 
     "nim.buildCommand": "js",
-    "nim.runOutputDirectory": "out"
+    "nim.runOutputDirectory": "out",
+    "nim.project": ["src/nimvscode.nim"]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # ChangeLog
 
+# 0.1.14 (02 Jan 2020)
+* Backend is no longer hardcoded for nimsuggest and nim check (#20)
+* Outline view is now hierarchical, types with fields under them
+* Workspace symbol search now works and no longer errors out
+
 # 0.1.13 (28 Dec 2020)
 * Updated logo thanks to @Knaque (#19)
 * Fixed a bug where a project was index on startup every time

--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Since then community members (noteably: @RSDuck, @dscottboggs, and yours truly) 
 Presently (2020-12-13) the difference between the two extensions is likley not particularly noticeable to the casual user, arguably it's seen more active maintenance. Some differences you might notice:
 * diagnostics for macro based errors
 * log highlighting and problem detection with links to source code
-* `nimsuggest` and `nim check` take backend into account so JS projects
 * IPC and process management for nimsuggest seem to handle more edge cases
 * support for multi-folder workspaces
 * uses vscode extension storage instead of `/tmp` (seems insecure)

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,3 +1,7 @@
+--backend:js
+--outdir:out
+--sourceMap
+
 define:nimsuggest
-define:js
 define:nodejs
+define:js

--- a/nimvscode.nimble
+++ b/nimvscode.nimble
@@ -1,6 +1,6 @@
 # Package
 
-version     = "0.1.13"
+version     = "0.1.14"
 author      = "saem"
 description = "Nim language support for Visual Studio Code written in Nim"
 license     = "MIT"

--- a/src/nimvscode/jsNode.nim
+++ b/src/nimvscode/jsNode.nim
@@ -95,6 +95,15 @@ iterator values*[K, V](m: Map[K, V]): V =
   yield v
   {.emit: "}".}
 
+iterator pairs*[K, V](m: Map[K, V]): (K, V) =
+  ## Yields the `entries` in a Map.
+  var k: K
+  var v: V
+  {.emit: "for (let e of `m`.entries()) {".}
+  {.emit: "  `k` = e[0]; `v` = e[1];".}
+  yield (k, v)
+  {.emit: "}".}
+
 iterator entries*[K, V](m: Map[K, V]): (K, V) =
   ## Yields the `entries` in a Map.
   var k: K

--- a/src/nimvscode/jsNode.nim
+++ b/src/nimvscode/jsNode.nim
@@ -35,7 +35,8 @@ var global* {.importc, nodecl.}: GlobalModule
 # static
 proc newMap*[K, V](): Map[K, V] {.importcpp: "(new Map())".}
 proc newArray*[T](size = 0): Array[T] {.importcpp: "(new Array(@))".}
-proc newArrayWith*[T](): Array[T] {.importcpp: "(new Array(@))", varargs.}
+proc newArray*[T](i: T): Array[T] {.importcpp: "(new Array(@))", varargs.}
+proc newArrayWith*[T](i: T): Array[T] {.importcpp: "(new Array(@))", varargs.}
 
 proc bufferConcat*(b: Array[Buffer]): Buffer {.importcpp: "(Buffer.concat(@))".}
 proc bufferAlloc*(size: cint): Buffer {.importcpp: "(Buffer.alloc(@))".}
@@ -47,12 +48,15 @@ proc clearInterval*(g: GlobalModule, t: Timeout): void {.importcpp.}
 
 # Array
 proc `[]`*[T](a: Array[T], idx: cint): T {.importcpp: "#[#]".}
+proc `[]`*[T](a: Array[T], idx: int): T {.importcpp: "#[#]".}
 proc `[]=`*[T](a: Array[T],idx: cint, val: T): T {.importcpp: "#[#]=#".}
 proc push*[T](a: Array[T], val: T): cint {.discardable, importcpp.}
 proc add*[T](a: Array[T], val: T) {.importcpp: "#.push(#)".}
 proc pop*[T](a: Array[T]): T {.importcpp.}
 proc shift*[T](a: Array[T]): T {.importcpp.}
+proc unshift*[T](a: Array[T]): T {.importcpp.}
 proc len*[T](a: Array[T]): cint {.importcpp: "#.length".}
+proc setLen*[T](a: Array[T], newlen: Natural): void {.importcpp: "#.length = #".}
 
 iterator items*[T](a: Array[T]): T =
   ## Yields the elements in an Array.

--- a/src/nimvscode/nimBinTools.nim
+++ b/src/nimvscode/nimBinTools.nim
@@ -1,0 +1,78 @@
+# Track down the various nim tools: `nim`, `nimble`, `nimsuggest`, ...
+
+from vscodeApi import vscode, showInformationMessage
+
+import jsNode, jsffi, jsNodePath, jsString, jsNodeFs, jsNodeCp
+from sequtils import mapIt, foldl, filterIt
+
+from strformat import fmt
+
+var binPathsCache = newMap[cstring, cstring]()
+
+proc getBinPath*(tool: cstring): cstring =
+  if binPathsCache[tool].toJs().to(bool): return binPathsCache[tool]
+  if not process.env["PATH"].isNil():
+    # add support for choosenim
+    process.env["PATH"] = path.join(
+      process.env["PATH"] & path.delimiter & process.env["HOME"],
+      ".nimble",
+      "bin")
+    if process.platform == "win32":
+      # USERPROFILE is the standard equivalent of HOME on windows.
+      process.env["PATH"] = path.join(
+        process.env["PATH"] & path.delimiter & process.env["USERPROFILE"],
+        ".nimble",
+        "bin")
+    var pathParts = process.env["PATH"].split(path.delimiter)
+    var endings = if process.platform == "win32": @[".exe", ".cmd", ""]
+                  else: @[""]
+
+    binPathsCache[tool] = pathParts.mapIt(
+        block:
+          var dir = it
+          endings.mapIt(path.join(dir, tool & it)))
+      .foldl(a & b)# flatten nested arays
+      .filterIt(fs.existsSync(it))[0]
+
+    if process.platform != "win32":
+      try:
+        var nimPath: cstring
+        case $(process.platform)
+        of "darwin":
+          nimPath = cp.execFileSync("readlink", @[binPathsCache[tool]]).toString().strip()
+          if nimPath.len > 0 and not path.isAbsolute(nimPath):
+            nimPath = path.normalize(path.join(path.dirname(binPathsCache[tool]), nimPath))
+        of "linux":
+          nimPath = cp.execFileSync("readlink", @[cstring("-f"), binPathsCache[
+              tool]]).toString().strip()
+        else:
+          nimPath = cp.execFileSync("readlink", @[binPathsCache[tool]]).toString().strip()
+
+        if nimPath.len > 0:
+          binPathsCache[tool] = nimPath
+      except:
+        discard #ignore
+  binPathsCache[tool]
+
+proc getNimExecPath*(executable: cstring = "nim"): cstring =
+  var path = getBinPath(executable)
+  if path.isNil():
+    vscode.window.showInformationMessage(fmt"No '{executable}' binary could be found in PATH environment variable")
+  return path
+
+proc getOptionalToolPath(tool: cstring): cstring =
+  if not binPathsCache.has(tool):
+    let execPath = path.resolve(getBinPath(tool))
+    if fs.existsSync(execPath):
+      binPathsCache[tool] = execPath
+    else:
+      binPathsCache[tool] = ""
+  return binPathsCache[tool]
+
+proc getNimPrettyExecPath*(): cstring =
+  ## full path to nimpretty executable or an empty string if not found
+  return getOptionalToolPath("nimpretty")
+
+proc getNimbleExecPath*(): cstring =
+  ## full path to nimble executable or an empty string if not found
+  return getOptionalToolPath("nimble")

--- a/src/nimvscode/nimBuild.nim
+++ b/src/nimvscode/nimBuild.nim
@@ -10,6 +10,8 @@ import jsString
 import jsre
 import jsconsole
 import sequtils
+from nimProjects import getProjects, isProjectMode, getProjectFileInfo,
+                        ProjectFileInfo, toLocalFile
 
 type
   CheckStacktrace* = ref object

--- a/src/nimvscode/nimBuild.nim
+++ b/src/nimvscode/nimBuild.nim
@@ -203,10 +203,6 @@ proc check*(filename: cstring, nimConfig: VscodeWorkspaceConfiguration): Promise
       )
     )
   else:
-    var backend: cstring = if nimConfig.has("buildCommand"):
-          "--backend:" & nimConfig.getStr("buildCommand")
-      else:
-          ""
     var projects = if not isProjectMode(): newArray(getProjectFileInfo(filename))
       else: getProjects()
 
@@ -214,7 +210,7 @@ proc check*(filename: cstring, nimConfig: VscodeWorkspaceConfiguration): Promise
       runningToolsPromises.add(nimExec(
           project,
           "check",
-          @[backend, "--listFullPaths".cstring, project.filePath],
+          @["--listFullPaths".cstring, project.filePath],
           true,
           parseErrors
       ))

--- a/src/nimvscode/nimBuild.nim
+++ b/src/nimvscode/nimBuild.nim
@@ -204,7 +204,7 @@ proc check*(filename: cstring, nimConfig: VscodeWorkspaceConfiguration): Promise
           "--backend:" & nimConfig.getStr("buildCommand")
       else:
           ""
-    var projects = if not isProjectMode(): @[getProjectFileInfo(filename)]
+    var projects = if not isProjectMode(): newArray(getProjectFileInfo(filename))
       else: getProjects()
 
     for project in projects:

--- a/src/nimvscode/nimBuild.nim
+++ b/src/nimvscode/nimBuild.nim
@@ -12,6 +12,7 @@ import jsconsole
 import sequtils
 from nimProjects import getProjects, isProjectMode, getProjectFileInfo,
                         ProjectFileInfo, toLocalFile
+from nimBinTools import getNimExecPath
 
 type
   CheckStacktrace* = ref object

--- a/src/nimvscode/nimFormatting.nim
+++ b/src/nimvscode/nimFormatting.nim
@@ -5,6 +5,8 @@ import jsNodeFs
 import jsconsole
 from strformat import fmt
 
+from nimBinTools import getNimPrettyExecPath
+
 var extensionContext*: VscodeExtensionContext
 
 proc provideDocumentFormattingEdits*(

--- a/src/nimvscode/nimImports.nim
+++ b/src/nimvscode/nimImports.nim
@@ -1,5 +1,4 @@
 import vscodeApi
-import nimUtils
 import jsNodeCp
 import jsNodeFs
 import jsNodePath
@@ -8,7 +7,9 @@ import jsString
 import jsre
 import jsconsole
 import jsffi
+
 from nimProjects import getProjects, isProjectMode
+from nimBinTools import getNimExecPath, getNimbleExecPath
 
 type
   NimbleModuleInfo = ref object

--- a/src/nimvscode/nimImports.nim
+++ b/src/nimvscode/nimImports.nim
@@ -8,6 +8,7 @@ import jsString
 import jsre
 import jsconsole
 import jsffi
+from nimProjects import getProjects, isProjectMode
 
 type
   NimbleModuleInfo = ref object

--- a/src/nimvscode/nimOutline.nim
+++ b/src/nimvscode/nimOutline.nim
@@ -10,8 +10,8 @@ proc provideWorkspaceSymbols(
 proc provideDocumentSymbols(
   doc: VscodeTextDocument,
   token: VscodeCancellationToken
-): Promise[seq[VscodeSymbolInformation]] =
-  return getFileSymbols(doc.filename, true, doc.getText())
+): Promise[seq[VscodeDocumentSymbol]] =
+  return getDocumentSymbols(doc.filename, true, doc.getText())
 
 type NimOutline* = ref object
   provideWorkspaceSymbols*: proc(

--- a/src/nimvscode/nimProjects.nim
+++ b/src/nimvscode/nimProjects.nim
@@ -1,0 +1,138 @@
+# modules handles the concept of nim projects. Projects are the project file
+# we pass to the compiler, nimsuggest, etc... 
+
+from vscodeApi import VscodeWorkspaceFolder, VscodeWorkspaceConfiguration,
+  vscode, getWorkspaceFolder, uriFile, asRelativePath, findFiles, get,
+  workspaceFolderLike, VscodeUri, VscodeUriChange, with, getConfiguration,
+  VscodeConfigurationChangeEvent, affectsConfiguration
+import jsffi, jsPromise, jsString, jsNode, jsre
+from jsNodePath import path, isAbsolute, parse, ParsedPath, dirname
+
+type
+  ProjectFileInfo* = ref object
+    wsFolder*: VscodeWorkspaceFolder
+    filePath*: cstring
+
+  ProjectMappingInfo* = ref object
+    fileRegex*: RegExp
+    projectPath*: cstring
+
+var
+  projects = newArray[ProjectFileInfo]()
+  projectMapping = newArray[ProjectMappingInfo]()
+
+proc getProjects*(): Array[ProjectFileInfo] = projects
+
+proc isProjectMode*(): bool = projects.len > 0
+
+proc toProjectInfo(filePath: cstring): ProjectFileInfo =
+  var workspace = vscode.workspace
+  if path.isAbsolute(filePath):
+    var workspaceFolder = workspace.getWorkspaceFolder(vscode.uriFile(filePath))
+    if workspaceFolder.toJs().to(bool):
+      return ProjectFileInfo{
+              wsFolder: workspaceFolder,
+              filePath: workspace.asRelativePath(filePath, false)
+        }
+  elif workspace.workspaceFolders.toJs().to(bool) and
+      workspace.workspaceFolders.len > 0:
+    var workspaceFolders = workspace.workspaceFolders
+    if workspaceFolders.len == 1:
+      return ProjectFileInfo{
+          wsFolder: workspaceFolders[0],
+          filePath: filePath
+      }
+    else:
+      var parsedPath: seq[cstring] = filePath.split("/")
+      if parsedPath.len > 1:
+        for folder in workspaceFolders:
+          if parsedPath[0] == folder.name:
+            return ProjectFileInfo{
+                wsFolder: folder,
+                filePath: filePath[parsedPath[0].len + 1..<filePath.len]
+            }
+
+  var parsedPath = path.parse(filePath)
+  return ProjectFileInfo{
+      wsFolder: vscode.workspaceFolderLike(
+              vscode.uriFile(parsedPath.dir),
+              cstring("root"),
+              cint(0)
+    ),
+      filePath: parsedPath.base
+  }
+
+proc toLocalFile*(project: ProjectFileInfo): cstring =
+  ## Returns a project file's file system path string
+  return project.wsFolder.uri.with(VscodeUriChange{
+          path: project.wsFolder.uri.path & "/" & project.filePath
+    }).fsPath
+
+proc getProjectFileInfo*(filename: cstring): ProjectFileInfo =
+  if not isProjectMode():
+    var projectInfo: ProjectFileInfo
+    if projectMapping.len > 0:
+      var uriPath = vscode.uriFile(filename).path
+      for mapping in projectMapping:
+        if mapping.fileRegex.test(uriPath):
+          continue
+        projectInfo = toProjectInfo(
+            uriPath.replace(mapping.fileRegex, mapping.projectPath))
+        break
+    if projectInfo.isNil():
+      projectInfo = toProjectInfo(filename)
+    return projectInfo
+
+  for project in projects:
+    if filename.startsWith(path.dirname(toLocalFile(project))):
+      return project
+  return projects[0]
+proc processConfigProjects(conf: JsObject): void =
+  ## updates `projects` from config `nim.projects`, if `nim.projects` changed
+  ## ensure that process `processConfigProjectMapping` is called thereafter
+  projects.setLen(0)
+
+  if conf.to(bool):
+    if conf.isJsArray:
+      for p in conf.to(seq[cstring]):
+        projects.add(toProjectInfo(p))
+    else:
+      vscode.workspace.findFiles(conf.to(cstring))
+        .then(proc(res: Array[VscodeUri]) =
+          if res.toJs.to(bool) and res.len > 0:
+            projects.add(toProjectInfo(res[0].fsPath))
+        )
+
+proc processConfigProjectMapping(conf: JsObject): void =
+  ## updates `projectMapping` from config `nim.projectMapping`, if
+  ## `nim.projects` changed ensure that `procesConfigProjects` is called first
+  
+  projectMapping.setLen(0)
+
+  if not conf.to(bool) and conf.jsTypeOf() == "object":
+    for k in keys(conf):
+      let path = conf[k].to(cstring)
+      projectMapping.add(ProjectMappingInfo{
+        fileRegex: newRegExp(k.toJs().to(cstring), ""), projectPath: path
+      })
+
+proc processConfig*(conf: VscodeWorkspaceConfiguration): void =
+  ## to be called whenever the config updates and on initial startup
+  
+  var
+    cfgProjects = conf.get("projects")
+    cfgMappings = conf.get("projectMapping")
+  
+  processConfigProjects(cfgProjects)
+  processConfigProjectMapping(cfgMappings)
+
+proc configUpdate*(cfgChg: VscodeConfigurationChangeEvent): void =
+  let
+    projectsChanged = cfgChg.affectsConfiguration("nim.projects")
+    mappingsChanged = cfgChg.affectsConfiguration("nim.projectMapping")
+    conf = vscode.workspace.getConfiguration("nim")
+
+  if projectsChanged:
+    processConfigProjects(conf.get("projects"))
+  if mappingsChanged:
+    processConfigProjectMapping(conf.get("projectMapping"))

--- a/src/nimvscode/nimSuggest.nim
+++ b/src/nimvscode/nimSuggest.nim
@@ -1,10 +1,10 @@
 import vscodeApi
 import nimSuggestExec
 import nimImports
-import nimUtils
 import jsString
 import jsre
 import jsconsole
+from nimProjects import getProjectFileInfo
 
 proc vscodeKindFromNimSym(kind: cstring): VscodeCompletionKind =
   case $kind:

--- a/src/nimvscode/nimSuggestExec.nim
+++ b/src/nimvscode/nimSuggestExec.nim
@@ -174,8 +174,6 @@ proc getNimSuggestProcess(nimProject: ProjectFileInfo): Future[
         args.add("--log".cstring)
       if nimConfig.getBool("useNimsuggestCheck"):
         args.add("--refresh:on".cstring)
-      if nimConfig.getBool("buildCommand"):
-        args.add("--backend:" & nimConfig.getStr("buildCommand"))
 
       args.add(nimProject.filePath)
       var cwd = nimProject.wsFolder.uri.fsPath

--- a/src/nimvscode/nimSuggestExec.nim
+++ b/src/nimvscode/nimSuggestExec.nim
@@ -16,6 +16,9 @@ import jsPromise
 import jsre
 import jsString
 
+from nimProjects import isProjectMode, toLocalFile,
+  getProjectFileInfo, ProjectFileInfo
+
 from dom import isNaN
 from strformat import fmt
 
@@ -92,8 +95,6 @@ proc initNimSuggest*() =
 
     console.log(versionOutput)
     console.log("Nimsuggest version: " & nimSuggestVersion)
-
-  discard vscode.workspace.onDidChangeConfiguration(prepareConfig)
 
 proc isNimSuggestVersion*(version: cstring): bool =
   ## Returns true if nimsuggest version is greater or equal to version

--- a/src/nimvscode/nimSuggestExec.nim
+++ b/src/nimvscode/nimSuggestExec.nim
@@ -17,7 +17,8 @@ import jsre
 import jsString
 
 from nimProjects import isProjectMode, toLocalFile,
-  getProjectFileInfo, ProjectFileInfo
+                        getProjectFileInfo, ProjectFileInfo
+from nimBinTools import getBinPath
 
 from dom import isNaN
 from strformat import fmt

--- a/src/nimvscode/nimUtils.nim
+++ b/src/nimvscode/nimUtils.nim
@@ -39,7 +39,7 @@ proc isWorkspaceFile*(filePath: cstring): bool =
   else:
     return false
 
-proc removeDirSync*(p: cstring): void =
+proc removeDirSync(p: cstring): void =
   if fs.existsSync(p):
     for entry in fs.readdirSync(p):
       var curPath = path.resolve(p, entry)

--- a/src/nimvscode/spec.nim
+++ b/src/nimvscode/spec.nim
@@ -1,22 +1,12 @@
 from vscodeApi import VscodeExtensionContext, VscodeWorkspaceConfiguration,
     VscodeOutputChannel,
     VscodeWorkspaceFolder
-from jsre import RegExp
 from jsNode import Map, Array
-# import jsNodeCp, elrpc
 
 type
   Backend* = cstring
   Timestamp* = cint
   NimsuggestId* = cstring
-
-  ProjectFileInfo* = ref object
-    wsFolder*: VscodeWorkspaceFolder
-    filePath*: cstring
-
-  ProjectMappingInfo* = ref object
-    fileRegex*: RegExp
-    projectPath*: cstring
 
   ExtensionState* = ref object
     ctx*: VscodeExtensionContext
@@ -25,10 +15,6 @@ type
 
     # TODO - rename to binPathsCache
     pathsCache*: Map[cstring, cstring]
-
-    # TODO - cached from config parsing, lift into separate object
-    projects*: Array[ProjectFileInfo]
-    projectMapping*: Array[ProjectMappingInfo]
 
     channel*: VscodeOutputChannel
 

--- a/src/nimvscode/spec.nim
+++ b/src/nimvscode/spec.nim
@@ -1,7 +1,6 @@
 from vscodeApi import VscodeExtensionContext, VscodeWorkspaceConfiguration,
     VscodeOutputChannel,
     VscodeWorkspaceFolder
-from jsNode import Map, Array
 
 type
   Backend* = cstring
@@ -12,9 +11,6 @@ type
     ctx*: VscodeExtensionContext
 
     config*: VscodeWorkspaceConfiguration
-
-    # TODO - rename to binPathsCache
-    pathsCache*: Map[cstring, cstring]
 
     channel*: VscodeOutputChannel
 

--- a/src/nimvscode/spec.nim
+++ b/src/nimvscode/spec.nim
@@ -1,0 +1,71 @@
+from vscodeApi import VscodeExtensionContext, VscodeWorkspaceConfiguration,
+    VscodeOutputChannel,
+    VscodeWorkspaceFolder
+from jsre import RegExp
+from jsNode import Map, Array
+# import jsNodeCp, elrpc
+
+type
+  Backend* = cstring
+  Timestamp* = cint
+  NimsuggestId* = cstring
+
+  ProjectFileInfo* = ref object
+    wsFolder*: VscodeWorkspaceFolder
+    filePath*: cstring
+
+  ProjectMappingInfo* = ref object
+    fileRegex*: RegExp
+    projectPath*: cstring
+
+  ExtensionState* = ref object
+    ctx*: VscodeExtensionContext
+
+    config*: VscodeWorkspaceConfiguration
+
+    # TODO - rename to binPathsCache
+    pathsCache*: Map[cstring, cstring]
+
+    # TODO - cached from config parsing, lift into separate object
+    projects*: Array[ProjectFileInfo]
+    projectMapping*: Array[ProjectMappingInfo]
+
+    channel*: VscodeOutputChannel
+
+# type
+#   SolutionKind* {.pure.} = enum
+#     skSingleFile, skFolder, skWorkspace
+
+#   NimsuggestProcess* = ref object
+#     process*: ChildProcess
+#     rpc*: EPCPeer
+#     startingPath*: cstring
+#     projectPath*: cstring
+#     backend*: Backend
+#     nimble*: VscodeUri
+#     updateTime*: Timestamp
+  
+#   ProjectKind* {.pure.} = enum
+#     pkNim, pkNims, pkNimble
+
+#   ProjectSource* {.pure.} = enum
+#     psDetected, psUserDefined
+
+#   Project* = ref object
+#     uri*: VscodeUri
+#     source*: ProjectSource
+#     nimsuggest*: NimsuggestId
+#     hasNimble*: bool
+#     matchesNimble*: bool
+#     case kind*: ProjectKind
+#     of pkNim:
+#       hasCfg*: bool
+#       hasNims*: bool
+#     of pkNims, pkNimble: discard
+
+#   ProjectCandidateKind* {.pure.} = enum
+#     pckNim, pckNims, pckNimble
+
+#   ProjectCandidate* = ref object
+#     uri*: VscodeUri
+#     kind*: ProjectCandidateKind

--- a/src/nimvscode/vscodeApi.nim
+++ b/src/nimvscode/vscodeApi.nim
@@ -77,6 +77,18 @@ type
     containerName*: cstring
     kind*: VscodeSymbolKind
     location*: VscodeLocation
+  
+  VscodeSymbolTag* {.pure, nodecl.} = enum 
+    deprecated = (1, "Deprecated")
+
+  VscodeDocumentSymbol* = ref object
+    children*: Array[VscodeDocumentSymbol]
+    detail*: cstring
+    kind*: VscodeSymbolKind
+    name*: cstring
+    `range`*: VscodeRange
+    selectionRange*: VscodeRange
+    tags: Array[VscodeSymbolTag]
 
   VscodeDiagnosticSeverity* {.nodecl, pure.} = enum
     ## Something not allowed by the rules of a language or other means.
@@ -537,6 +549,21 @@ proc newSignatureInformation*(vscode: Vscode, kind: cstring,
 proc newParameterInformation*(vscode: Vscode,
   name: cstring): VscodeParameterInformation {.
   importcpp: "(new #.ParameterInformation(@))".}
+proc newDocumentSymbol*(
+  vscode: Vscode,
+  name: cstring,
+  detail: cstring,
+  kind: VscodeSymbolKind,
+  rng: VscodeRange,
+  selectionRange: VscodeRange
+): VscodeDocumentSymbol {.importcpp: "(new #.DocumentSymbol(@))".}
+proc newSymbolInformation*(
+  vscode: Vscode,
+  name: cstring,
+  kind: VscodeSymbolKind,
+  container: cstring,
+  loc: VscodeLocation
+): VscodeSymbolInformation {.importcpp: "(new #.SymbolInformation(@))".}
 proc newSymbolInformation*(
   vscode: Vscode,
   name: cstring,
@@ -544,7 +571,7 @@ proc newSymbolInformation*(
   rng: VscodeRange,
   file: VscodeUri,
   container: cstring
-): VscodeSymbolInformation {.importcpp: "(new #.SymbolInformation(@))".}
+): VscodeSymbolInformation {.importcpp: "(new #.SymbolInformation(@))", deprecated.}
 proc newVscodeHover*(vscode: Vscode, contents: VscodeMarkedString): VscodeHover {.
   importcpp: "(new #.Hover(@))".}
 proc newVscodeHover*(vscode: Vscode, contents: Array[

--- a/src/nimvscode/vscodeExt.nim
+++ b/src/nimvscode/vscodeExt.nim
@@ -278,7 +278,6 @@ proc activate*(ctx: VscodeExtensionContext): void =
   state = ExtensionState(
     ctx: ctx,
     config: config,
-    pathsCache: newMap[cstring, cstring](),
     channel: vscode.window.createOutputChannel("Nim")
   )
   nimUtils.ext = state


### PR DESCRIPTION
* Fixed workspace symbol search
* Outline view is now hierarchical
* Fixes #20 as the backend is no longer hard coded for nimsuggest and nim check
* Project state is now managed separatedly from nimUtils in its own module (internal refactor)
* Various nim binary lookup and caching separated into its own module
* Stopped exporting methods unnecessarily in nimUtils and various other modules