### PR TITLE
Fix parameters of workspaceFolderLike creation

### DIFF
--- a/src/nimvscode/nimProjects.nim
+++ b/src/nimvscode/nimProjects.nim
@@ -3,7 +3,7 @@
 
 from vscodeApi import VscodeWorkspaceFolder, VscodeWorkspaceConfiguration,
   vscode, getWorkspaceFolder, uriFile, asRelativePath, findFiles, get,
-  workspaceFolderLike, VscodeUri, VscodeUriChange, with, getConfiguration,
+  newWorkspaceFolderLike, VscodeUri, VscodeUriChange, with, getConfiguration,
   VscodeConfigurationChangeEvent, affectsConfiguration
 import jsffi, jsPromise, jsString, jsNode, jsre
 from jsNodePath import path, isAbsolute, parse, ParsedPath, dirname
@@ -54,7 +54,7 @@ proc toProjectInfo(filePath: cstring): ProjectFileInfo =
 
   var parsedPath = path.parse(filePath)
   return ProjectFileInfo{
-      wsFolder: vscode.workspaceFolderLike(
+      wsFolder: newWorkspaceFolderLike(
               vscode.uriFile(parsedPath.dir),
               cstring("root"),
               cint(0)

--- a/src/nimvscode/vscodeApi.nim
+++ b/src/nimvscode/vscodeApi.nim
@@ -582,7 +582,7 @@ proc newVscodeHover*(vscode: Vscode, contents: Array[VscodeMarkedString],
   `range`: VscodeRange): VscodeHover {.importcpp: "(new #.Hover(@))".}
 proc uriFile*(vscode: Vscode, file: cstring): VscodeUri {.
   importcpp: "(#.Uri.file(@))".}
-proc workspaceFolderLike*(vscode: Vscode, uri: VscodeUri, name: cstring,
+proc newWorkspaceFolderLike*(uri: VscodeUri, name: cstring,
   index: cint): VscodeWorkspaceFolder {.
   importcpp: "({uri:#, name:#, index:#})".}
 


### PR DESCRIPTION
The old `workspaceFolderLike` procedure includes parameter `vscode`, resulting in a bad creation ( `{uri: (vscode), name: (uri), index: (name)}` ). The fix corrects it.

The fix enables "hover" and "go to definition" in files _outside_ current project folder.