### PR TITLE
Add nimble tasks to build and install VSIX

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,12 @@ This extension relies on nimsuggest for code completion. Nimsuggest is basically
 * You can open a Nim code base to try it out
   * If you want to try it out on the extension source itself, create a new workspace and add the source as a folder to the workspace so VS Code doesn't take you back to the development window
 
-Alternatively, feel free to give side-loading a shot by building the extension first via npm.
+Alternatively, feel free to give side-loading a shot.
+
+### Side-loading the Extension
+
+* Run `nimble vsix` to build the extension package to `out/nimvscode-<version>.vsix`
+* Run `nimble install_vsix` if you have VS Code on `PATH`, otherwise select `Install from VSIX` from the command palette (`cmd-shift-p`) and choose `out/nimvscode-<version>.vsix`.
 
 ---
 

--- a/nimvscode.nimble
+++ b/nimvscode.nimble
@@ -21,6 +21,12 @@ task main, "This compiles the vscode Nim extension":
 task release, "This compiles a release version":
   exec "nim js -d:release -d:danger --outdir:out --checks:off --sourceMap src/nimvscode.nim"
 
+task vsix, "Build VSIX package":
+  exec "./node_modules/.bin/vsce package --out out"
+
+task install_vsix, "Install the VSIX package":
+  exec "code --install-extension out/nimvscode-" & version & ".vsix"
+
 # Tasks for maintenance
 task audit_node_deps, "Audit Node.js dependencies":
   exec "npm audit"


### PR DESCRIPTION
I added these to aid the repetitive task and so that I don;t have to
lookup how to do it each time I revisit this project.

I also added the instructions for side-loading the extension to
`README.md`.