### PR TITLE
Allow period in custom numeric literals

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1479,7 +1479,7 @@
     "custom_literal": {
       "patterns": [
         {
-          "match": "\\b(\\d[_\\d]*)'(\\w+)",
+          "match": "\\b(\\d[_\\d]*)(\\.[_\\d]+)?'(\\w+)",
           "name": "constant.numeric.custom.lit.nim"
         }
       ]


### PR DESCRIPTION
This allows literals such as  `3.14'fp` to be highlighted correctly

Before:
![image](https://user-images.githubusercontent.com/569607/137953010-393472a7-07d1-4d13-91ca-da805bdae8f3.png)

After:
![image](https://user-images.githubusercontent.com/569607/137952881-3916c56f-7805-4223-9eaa-4df9492d1520.png)
