### PR TITLE
fix existsSync logic for triggering mkdirSync

### DIFF
--- a/src/nimvscode.nim
+++ b/src/nimvscode.nim
@@ -258,7 +258,7 @@ proc runFile(): void =
               rootPath = folder.uri.fsPath
               break
           if rootPath != "":
-            if fs.existsSync(path.join(rootPath, outputDirConfig)):
+            if not fs.existsSync(path.join(rootPath, outputDirConfig)):
               fs.mkdirSync(path.join(rootPath, outputDirConfig))
             outputParams = " --out:\"" & path.join(
                     outputDirConfig,


### PR DESCRIPTION
This was giving errors when running a file if the output directory already existed, it appears the logic was just reversed.