### PR TITLE
Use the last reported location for errors in parseExpr/parseStmt code

### DIFF
--- a/src/nimBuild.nim
+++ b/src/nimBuild.nim
@@ -141,27 +141,22 @@ proc parseErrors(lines: seq[cstring]): seq[CheckResult] =
       if messageText.len < 1024:
         messageText &= nodeOs.eol & line
     else:
-      var
-        file = match[2]
-        lineStr = match[3]
-        charStr = match[5]
       let
         severity = match[7]
         msg = match[8]
-
       # file may be undefined when there's an error in code
       # created with parseExpr/parseStmt
       # as a workaround we duplicate the last location in the stacktrace
       # There always has to be atleast the location where the macro
       # called which contains the faulty parseExpr/parseStmt
-      if file.toJs() == jsUndefined:
-        file = lastFile
-        lineStr = lastLineStr
-        charStr = lastCharStr
-      else:
-        lastFile = file
-        lastLineStr = lineStr
-        lastCharStr = charStr
+        (file, lineStr, charStr) =
+          if match[2].toJs() == jsUndefined:
+            (lastfile, lastLineStr, lastCharStr)
+          else:
+            lastFile = match[2]
+            lastLineStr = match[3]
+            lastCharStr = match[5]
+            (match[2], match[3], match[5])
 
       if severity == nil:
         stacktrace.add(CheckStacktrace(


### PR DESCRIPTION
Consider these snippets:

```nim
import strformat
echo &"{test}"
```

```nim
import strformat

proc test[T](): T =
    result *= 2

proc miauz[T](): T =
    echo &"{test[string]()}"

miauz[int]()
```

Currently the diagonstics provider throws an exception with code like this because it cannot handle that there's no filename in the error log:

```
...\strformaterror.nim(2, 6) template/generic instantiation of `&` from here
(1, 1) Error: undeclared identifier: 'test'
candidates (edit distance, scope distance); see '--spellSuggest':
 (2, 4): 'lent' [type declared in C:\Nim\lib\system.nim(307, 6)]
 (2, 4): 'reset' [proc declared in C:\Nim\lib\system.nim(1000, 6)]
 (2, 4): 'set' [type declared in C:\Nim\lib\system.nim(300, 3)]
```

I was thinking about putting in some fake filename, I thought that could be confusing, so I settled with repeating the last reported location instead (see also the comment in the code for rationale).

In an idea world, it would create an virtual file where you could see the generated code with the error in it, though then again parseExpr/parseStmt aren't used that often in Nim.

Alternative ideas are welcome!