### PR TITLE
handle nimsuggest exit signal being null

### DIFF
--- a/src/nimSuggestExec.nim
+++ b/src/nimSuggestExec.nim
@@ -204,8 +204,10 @@ proc getNimSuggestProcess(nimProject: ProjectFileInfo): Future[
       )
       process.onClose(proc(code: cint, signal: cstring): void =
         cleanupDirtyFileFolder(process.pid)
-        var codeStr = if code.toJs().isNull(): "unknown" else: $(code)
-        var msg = fmt"nimsuggest {process.pid} (args: {args.join("" "")}) closed with code: {codeStr} and signal: {signal}"
+        let
+          codeStr = if code.toJs().isNull(): "unknown" else: $(code)
+          signalStr = if signal == nil: "null" else: $signal
+          msg = fmt"nimsuggest {process.pid} (args: {args.join("" "")}) closed with code: {codeStr} and signal: {signalStr}"
         if code != 0:
           console.error(msg)
         else:


### PR DESCRIPTION
#75 some people seem to have an issue where nimsuggest quits for a reason not yet understood (by me). I couldn't figure out why that is, though by replacing the nimsuggest executable through one which just exits with code 1 I could get atleast the same exception which should be solved by this.