### PR TITLE
remove non reserved keywords from highlighting of unused res. keywords

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -168,7 +168,7 @@
     },
     {
       "comment": "Invalid and unused keywords.",
-      "match": "(\\b(generic|interface|lambda|out|shared)\\b)",
+      "match": "(\\b(interface|out)\\b)",
       "name": "invalid.illegal.invalid-keyword.nim"
     },
     {


### PR DESCRIPTION
i wanted to have a variable `shared` for input to a function, but it was highlighted as an unused reserved keyword. it was not in the list of reserved keywords so i removed it and the others in the matching group which also were not in the list as they didn't seem to need to be there.