### PR TITLE
change highlighting of static to match block, if

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -148,7 +148,7 @@
     },
     {
       "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield|static)\\b",
+      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield|(static(?= *:)))\\b",
       "name": "keyword.control.nim"
     },
     {

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -148,7 +148,7 @@
     },
     {
       "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield|(static(?= *:)))\\b",
+      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield|(static(?= *:))|of)\\b",
       "name": "keyword.control.nim"
     },
     {
@@ -163,7 +163,7 @@
     },
     {
       "comment": "Other keywords.",
-      "match": "(\\b(addr|as|asm|atomic|bind|cast|const|converter|concept|defer|discard|distinct|div|enum|export|from|import|include|let|mod|mixin|object|of|ptr|ref|shl|shr|static|type|using|var|tuple|iterator|macro|func|method|proc|template)\\b)",
+      "match": "(\\b(addr|as|asm|atomic|bind|cast|const|converter|concept|defer|discard|distinct|div|enum|export|from|import|include|let|mod|mixin|object|ptr|ref|shl|shr|static|type|using|var|tuple|iterator|macro|func|method|proc|template)\\b)",
       "name": "keyword.other.nim"
     },
     {

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -148,7 +148,7 @@
     },
     {
       "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield)\\b",
+      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield|static)\\b",
       "name": "keyword.control.nim"
     },
     {


### PR DESCRIPTION
i felt that having static highlighted like var, seq, ref, etc instead of block, if, for, (and at least in my case, proc and template) didn't make sense