### PR TITLE
 handle `of` as a binary keyword

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -148,7 +148,7 @@
     },
     {
       "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|(?<!(?:if|elif|when|while)[^\\n]*)of(?=[^\\n]*\\:)|raise|return|(static(?= *:))|try|when|while|yield)\\b",
+      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|(?<!(?:if|elif|when|while)[^\\n]*)of(?=[^\\n\\)]*\\:)|raise|return|(static(?= *:))|try|when|while|yield)\\b",
       "name": "keyword.control.nim"
     },
     {

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -148,7 +148,7 @@
     },
     {
       "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|(?<!(?:if|elif|when)[^\\n]*)of(?=[^\\n]*\\:)|raise|return|(static(?= *:))|try|when|while|yield)\\b",
+      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|(?<!(?:if|elif|when|while)[^\\n]*)of(?=[^\\n]*\\:)|raise|return|(static(?= *:))|try|when|while|yield)\\b",
       "name": "keyword.control.nim"
     },
     {

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -148,7 +148,7 @@
     },
     {
       "comment": "Keywords that affect program control flow or scope.",
-      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|raise|return|try|when|while|yield|(static(?= *:))|of)\\b",
+      "match": "\\b(block|break|case|continue|do|elif|else|end|except|finally|for|if|(?<!(?:if|elif|when)[^\\n]*)of(?=[^\\n]*\\:)|raise|return|(static(?= *:))|try|when|while|yield)\\b",
       "name": "keyword.control.nim"
     },
     {
@@ -163,7 +163,7 @@
     },
     {
       "comment": "Other keywords.",
-      "match": "(\\b(addr|as|asm|atomic|bind|cast|const|converter|concept|defer|discard|distinct|div|enum|export|from|import|include|let|mod|mixin|object|ptr|ref|shl|shr|static|type|using|var|iterator|macro|func|method|proc|template)\\b)",
+      "match": "(\\b(addr|as|asm|atomic|bind|cast|const|converter|concept|defer|discard|distinct|div|enum|export|from|import|include|let|mod|mixin|object|of|ptr|ref|shl|shr|static|type|using|var|iterator|macro|func|method|proc|template)\\b)",
       "name": "keyword.other.nim"
     },
     {


### PR DESCRIPTION
only match `of` as a control keyword if it is not in an if/elif/when and is followed by a colon. additionally reorder `keyword.control.nim` match|multiple|strings to be (hopefully) alphabetical order

see #91, #90, #86 