### PR TITLE
Make compatible with latest Nim and Windows paths; misc cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "@types/node": "^10.17.17",
         "@types/vscode": "^1.27.0",
         "js-yaml": "^4.1.0",
+        "npm-check-updates": "^13.0.0",
         "ovsx": "^0.2.1",
         "typescript": "^2.6.1",
         "vsce": "^1.95.0",

--- a/src/nimBuild.nim
+++ b/src/nimBuild.nim
@@ -166,7 +166,7 @@ proc parseErrors(lines: seq[cstring]): seq[CheckResult] =
           msg: msg))
       else:
         if messageText.len > 0 and result.len > 0:
-          result[^1].msg &= nodeOs.eol & messageText
+          result[^1].msg &= nodeOs.eol & messageText.cstring
 
         messageText = ""
         result.add(CheckResult(
@@ -179,7 +179,7 @@ proc parseErrors(lines: seq[cstring]): seq[CheckResult] =
         ))
         stacktrace.setLen(0)
   if messageText.len > 0 and result.len > 0:
-    result[^1].msg &= nodeOs.eol & messageText
+    result[^1].msg &= nodeOs.eol & messageText.cstring
 
 proc parseNimsuggestErrors(items: seq[NimSuggestResult]): seq[CheckResult] =
   var ret: seq[CheckResult] = @[]
@@ -309,7 +309,7 @@ proc execSelectionInTerminal*(#[ doc:VscodeTextDocument ]#) {.async.} =
       var execPath = getNimExecPath(executable)
       if execPath.isNil() or execPath.strip() == "":
         vscode.window.showInformationMessage(
-          fmt"Binary named '{executable}' not found in PATH environment variable"
+          fmt"Binary named '{executable}' not found in PATH environment variable".cstring
         )
         return
       evalTerminal = vscode.window.createTerminal("Nim Console")

--- a/src/nimFormatting.nim
+++ b/src/nimFormatting.nim
@@ -28,8 +28,8 @@ proc provideDocumentFormattingEdits*(
       getNimPrettyExecPath(),
       @[
           cstring "--backup:OFF",
-          "--indent:" & $(config.getInt("nimprettyIndent")),
-          "--maxLineLen:" & $(config.getInt("nimprettyMaxLineLen")),
+          "--indent:" & cstring($(config.getInt("nimprettyIndent"))),
+          "--maxLineLen:" & cstring($(config.getInt("nimprettyMaxLineLen"))),
           file
     ],
     SpawnSyncOptions{cwd: extensionContext.extensionPath}
@@ -39,7 +39,7 @@ proc provideDocumentFormattingEdits*(
     console.error("Formatting failed:", res.error)
     {.emit: "throw `res`.error;".}
   elif not fs.existsSync(file):
-    var msg: cstring = fmt"Formatting failed - file not found: {file}"
+    var msg: cstring = fmt"Formatting failed - file not found: {file}".cstring
     console.error(msg)
     {.emit: "throw { message: `msg` }".}
     return ret

--- a/src/nimImports.nim
+++ b/src/nimImports.nim
@@ -136,8 +136,8 @@ proc initNimbleModules(rootDir: cstring): Promise[seq[cstring]] =
             of "desc": nimbleModule.description = value
         nimbleModules.add(nimbleModule)
       except:
-        console.log("Module incorrect " & moduleName, getCurrentExceptionMsg())
-  )
+        console.log("Module incorrect " & moduleName, getCurrentExceptionMsg().cstring)
+  ).toJs().to(Promise[seq[cstring]])
 
 proc getImports*(prefix: cstring, projectDir: cstring): seq[
     VscodeCompletionItem] =

--- a/src/nimLsp.nim
+++ b/src/nimLsp.nim
@@ -26,7 +26,7 @@ proc startLanguageServer(tryInstall: bool, state: ExtensionState) =
       vscode.window.showInformationMessage("Unable to find/install `nimlangserver`.")
   else:
     let nimlangserver = path.resolve(rawPath);
-    console.log(fmt"nimlangserver found: {nimlangserver}")
+    console.log(fmt"nimlangserver found: {nimlangserver}".cstring)
     console.log("Starting nimlangserver.")
     let
       serverOptions = ServerOptions{

--- a/src/nimProjects.nim
+++ b/src/nimProjects.nim
@@ -6,7 +6,7 @@ from platform/vscodeApi import VscodeWorkspaceFolder,
   asRelativePath, findFiles, get, newWorkspaceFolderLike, VscodeUri,
   VscodeUriChange, with, getConfiguration, VscodeConfigurationChangeEvent,
   affectsConfiguration
-import std/jsffi
+import std/[jsconsole, jsffi]
 import platform/js/[jsPromise, jsString, jsNode, jsre]
 from platform/js/jsNodePath import path, isAbsolute, parse, ParsedPath, dirname
 
@@ -104,7 +104,8 @@ proc processConfigProjects(conf: JsObject): void =
         .then(proc(res: Array[VscodeUri]) =
           if res.toJs.to(bool) and res.len > 0:
             projects.add(toProjectInfo(res[0].fsPath))
-        )
+        ).catch(proc(reason: JsObject) =
+          console.error("nimProjects - processConfigProjects Failed", reason))
 
 proc processConfigProjectMapping(conf: JsObject): void =
   ## updates `projectMapping` from config `nim.projectMapping`, if

--- a/src/nimSuggest.nim
+++ b/src/nimSuggest.nim
@@ -92,7 +92,7 @@ proc provideCompletionItems*(
                   vscodeKindFromNimSym(item.suggest)
                 )
               suggestion.detail = nimSymDetails(item)
-              suggestion.sortText = (cstring"0000" & $(suggestions.len))[^4 .. ^1]
+              suggestion.sortText = (cstring("0000" & $suggestions.len))[^4 .. ^1]
               # use predefined text to disable suggest sorting
               suggestion.documentationMD = vscode.newMarkdownString(
                   item.documentation)

--- a/src/nimUtils.nim
+++ b/src/nimUtils.nim
@@ -43,7 +43,7 @@ proc removeDirSync(p: cstring): void =
     fs.rmdirSync(p)
 
 proc getDirtyFileFolder*(nimsuggestPid: cint): cstring =
-  path.join(extensionContext.storagePath, "vscodenimdirty_" & $nimsuggestPid)
+  path.join(extensionContext.storagePath, "vscodenimdirty_" & cstring($nimsuggestPid))
 
 proc cleanupDirtyFileFolder*(nimsuggestPid: cint) =
   removeDirSync(getDirtyFileFolder(nimsuggestPid))
@@ -52,7 +52,7 @@ proc getDirtyFile*(nimsuggestPid: cint, filepath, content: cstring): cstring =
   ## temporary file path of edited document
   ## for each nimsuggest instance each file has a unique dirty file
   var dirtyFilePath = path.normalize(
-      path.join(getDirtyFileFolder(nimsuggestPid), $int(hash(filepath)) & ".nim")
+      path.join(getDirtyFileFolder(nimsuggestPid), cstring($int(hash(filepath))) & ".nim")
   )
   fs.writeFileSync(dirtyFilePath, content)
   return dirtyFilePath
@@ -72,14 +72,14 @@ proc padStart(len: cint, input: cstring): cstring =
   return output & input
 proc cleanDateString(date: DateTime): cstring =
   var year = date.getFullYear()
-  var month = padStart(2, $(date.getMonth()))
-  var dd = padStart(2, $(date.getDay()))
-  var hour = padStart(2, $(date.getHours()))
-  var minute = padStart(2, $(date.getMinutes()))
-  var second = padStart(2, $(date.getSeconds()))
-  var milliseconds = padStart(3, $(date.getMilliseconds()))
+  var month = padStart(2, cstring($(date.getMonth())))
+  var dd = padStart(2, cstring($(date.getDay())))
+  var hour = padStart(2, cstring($(date.getHours())))
+  var minute = padStart(2, cstring($(date.getMinutes())))
+  var second = padStart(2, cstring($(date.getSeconds())))
+  var milliseconds = padStart(3, cstring($(date.getMilliseconds())))
   return cstring(fmt"{year}-{month}-{dd} {hour}:{minute}:{second}.{milliseconds}")
 
 proc outputLine*(message: cstring): void =
   ## Prints message in Nim's output channel
-  channel.appendLine(fmt"{cleanDateString(newDate())} - {message}")
+  channel.appendLine(fmt"{cleanDateString(newDate())} - {message}".cstring)

--- a/src/platform/languageClientApi.nim
+++ b/src/platform/languageClientApi.nim
@@ -1,5 +1,5 @@
 import std/jsffi
-import js/[jsPromise, asyncjs, jsre, jsNode]
+import js/[jsPromise, jsNode]
 
 export jsffi, jsPromise, jsNode
 

--- a/src/store/flatdbnode.nim
+++ b/src/store/flatdbnode.nim
@@ -153,7 +153,7 @@ proc processCommands*(db: FlatDb) {.async.} =
         await fh.writeFile(content)
       except:
         console.error(
-            getCurrentExceptionMsg(),
+            getCurrentExceptionMsg().cstring,
             getCurrentException(),
             op
         )
@@ -166,7 +166,7 @@ proc processCommands*(db: FlatDb) {.async.} =
       except:
         console.error(
             getCurrentException(),
-            getCurrentExceptionMsg()
+            getCurrentExceptionMsg().cstring
         )
         cmd.afterCallback(CmdResult.failure)
     of DbCmdKind.backup:
@@ -185,7 +185,7 @@ proc processCommands*(db: FlatDb) {.async.} =
       except:
         console.error(
             getCurrentException(),
-            getCurrentExceptionMsg()
+            getCurrentExceptionMsg().cstring
         )
         cmd.afterCallback(CmdResult.failure)
     of DbCmdKind.close:
@@ -196,7 +196,7 @@ proc processCommands*(db: FlatDb) {.async.} =
       except:
         console.error(
             getCurrentException(),
-            getCurrentExceptionMsg()
+            getCurrentExceptionMsg().cstring
         )
         cmd.afterCallback(CmdResult.failure)
 

--- a/src/tools/elrpc.nim
+++ b/src/tools/elrpc.nim
@@ -27,7 +27,7 @@ proc envelop(content: cstring): cstring =
     strLen = content.len
     length = util.newTextEncoder().encode(content).len
     hexLength = ("000000" & length.toString(16))[^6..^1]
-  console.log(fmt"strLen:{strLen}, length:{length}, hexLength:{hexLength}, content:{content}")
+  console.log(fmt"strLen:{strLen}, length:{length}, hexLength:{hexLength}, content:{content}".cstring)
   return hexLength & content
 
 proc generateUid(epc: EPCPeer): cint =
@@ -42,10 +42,10 @@ proc write(epc: EPCPeer, msg: cstring): void =
     epc.queue.add(msg)
   of flowing:
     var expectedBytes = epc.socket.bytesWritten + msg.len
-    console.log(epc.id, fmt"flowing write {expectedBytes} msg:", msg)
+    console.log(epc.id, fmt"flowing write {expectedBytes} msg:".cstring, msg)
     var flushed = epc.socket.write(msg)
     if expectedBytes != epc.socket.bytesWritten:
-      console.error(epc.id, fmt"Bytes written expected {expectedBytes}, actual {epc.socket.bytesWritten}")
+      console.error(epc.id, fmt"Bytes written expected {expectedBytes}, actual {epc.socket.bytesWritten}".cstring)
     if not flushed:
       console.log(epc.id, "write blocked")
       epc.queueState = QueueState.blocked
@@ -88,7 +88,7 @@ proc newEPCPeer(id: cint, socket: NetSocket): EPCPeer =
               var contentSexp: seq[SExpNode] = content.getElems()
               var guid = cint(contentSexp[1].getNum())
               var handle = epc.sessions[guid]
-              console.log(fmt"{epc.id} onData - handling:{guid} length:{length}")
+              console.log(fmt"{epc.id} onData - handling:{guid} length:{length}".cstring)
               handle(contentSexp)
               epc.sessions.delete(guid)
           except:
@@ -158,7 +158,7 @@ proc callMethod*(epc: EPCPeer, meth: cstring, params: seq[SExpNode]): Promise[
           of "return-error", "epc-error": reject(data[2].toJs())
           else: console.error("Unknown error handling sexp")
 
-      epc.write(envelop(payload))
+      epc.write(envelop(payload.cstring))
   )
 
 proc stop*(epc: EPCPeer): void =
@@ -179,7 +179,7 @@ proc startClient*(id, port: cint): Promise[EPCPeer] =
       except:
         console.error(
             "Failed to start client with message: '",
-            getCurrentExceptionMsg(),
+            getCurrentExceptionMsg().cstring,
             "' see exception:",
             getCurrentException()
         )

--- a/src/tools/nimBinTools.nim
+++ b/src/tools/nimBinTools.nim
@@ -28,7 +28,7 @@ proc getBinPath*(tool: cstring): cstring =
     let paths = pathParts.mapIt(
         block:
           var dir = it
-          endings.mapIt(path.join(dir, tool & it)))
+          endings.mapIt(path.join(dir, tool & it).cstring))
       .foldl(a & b)# flatten nested arays
       .filterIt(fs.existsSync(it))
 


### PR DESCRIPTION
* Update `asynjs.then` uses that did nothing with the future return value
  to be compatible with newer `asyncjs` versions.
* Get rid of implicit cstring warnings.
* Remove unused or duplicate imports.
* Make Nimble task paths cross-platform.
* Make file search paths cross-platform.
* Add missing maintenance NPM package to `package.json`.
* Removed OVSX access token since it's already in the correct env var.

Fixes  #79