### PR TITLE
Fix project mapping schema & build issues

### DIFF
--- a/config.nims
+++ b/config.nims
@@ -1,0 +1,14 @@
+import os
+
+switch("backend", "js")
+switch("outdir", "out")
+switch("sourceMap", "on")
+switch("path", "src")
+switch("define", "nimsuggest")
+switch("define", "nodejs")
+switch("define", "js")
+
+# Add nim's installation path to the search paths so that nimsuggest can be found
+let nimInstallationDir = absolutePath(splitPath(getCurrentCompilerExe()).head / "..")
+if dirExists(nimInstallationDir / "nimsuggest"):
+    switch("path", nimInstallationDir)

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,9 +1,0 @@
---backend:js
---outdir:out
---sourceMap
-
---path:"src/"
-
-define:nimsuggest
-define:nodejs
-define:js

--- a/package.json
+++ b/package.json
@@ -202,15 +202,19 @@
                 "nim.projectMapping": {
                     "type": "array",
                     "default": [],
-                    "description": "For non project mode list of per file project mapping using regex, for example ```{\"fileRegex\": \"(.*).inim\", \"projectFile\": \"$1.nim\"}```",
-                    "properties": {
-                        "fileRegex": {
-                            "type": "string",
-                            "description": "Source file regex"
-                        },
-                        "projectFile": {
-                            "type": "string",
-                            "description": "Project file path"
+                    "description": "For non project mode list of per file project mapping using regex, for example ```[{\"fileRegex\": \"(.*).inim\", \"projectFile\": \"$1.nim\"}]```",
+                    "items": {
+                        "type": "object",
+                        "title": "mapping",
+                        "properties": {
+                            "fileRegex": {
+                                "type": "string",
+                                "description": "Source file regex"
+                            },
+                            "projectFile": {
+                                "type": "string",
+                                "description": "Project file path"
+                            }
                         }
                     },
                     "scope": "resource"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nimvscode",
     "displayName": "Nim",
     "description": "Nim language support for Visual Studio Code written in Nim",
-    "version": "0.1.26",
+    "version": "0.1.27",
     "publisher": "nimsaem",
     "author": {
         "name": "Saem"


### PR DESCRIPTION
I was seeing errors like this in the Nim Language Server output:

> DBG Failed to parse the configuration.

Symbol lookup wasn’t working well with the lsp backend.

It's not [documented](https://code.visualstudio.com/api/references/contribution-points) but according to [this stack overflow](https://stackoverflow.com/questions/38678283/contributing-configuration-of-type-array-in-vscode-extension), configuration entries with type `array` must nest the properties under `items`.

Additionally, when running `nimble vsix` I was getting this error:

> vscode-nim/src/tools/elrpc.nim(6, 18) Error: cannot open file: nimsuggest/sexp

This is because *nimsuggest* is not in the nim installation’s lib directory.

These changes explicitly add the nim installation’s root directory to the search path so that nimsuggest can be found when compiling.

On my system, `nim dump` in the *vscode-nim* directory gives these paths:

```
/Users/user/Development/vscode-nim/src
/Users/user/.asdf/installs/nim/1.6.12/lib/pure
/Users/user/.asdf/installs/nim/1.6.12/lib/core
/Users/user/.asdf/installs/nim/1.6.12/lib/arch
/Users/user/.asdf/installs/nim/1.6.12/lib/pure/unidecode
/Users/user/.asdf/installs/nim/1.6.12/lib/js
/Users/user/.asdf/installs/nim/1.6.12/lib/posix
/Users/user/.asdf/installs/nim/1.6.12/lib/windows
/Users/user/.asdf/installs/nim/1.6.12/lib/wrappers/linenoise
/Users/user/.asdf/installs/nim/1.6.12/lib/wrappers
/Users/user/.asdf/installs/nim/1.6.12/lib/impure
/Users/user/.asdf/installs/nim/1.6.12/lib/pure/concurrency
/Users/user/.asdf/installs/nim/1.6.12/lib/pure/collections
/Users/user/.asdf/installs/nim/1.6.12/lib/deprecated/pure
/Users/user/.asdf/installs/nim/1.6.12/lib/deprecated/core
/Users/user/.asdf/installs/nim/1.6.12/lib
/Users/user/.asdf/installs/nim/1.6.12/lib
/Users/user/.asdf/installs/nim/1.6.12/lib
```

But *nimsuggest* is located at */Users/user/.asdf/installs/nim/1.6.12/nimsuggest*.