### PR TITLE
Fix syntax highlighting

### DIFF
--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1174,6 +1174,9 @@
           "include": "#fmt_string"
         },
         {
+          "include": "#fmt_string_call_triple"
+        },
+        {
           "include": "#fmt_string_call"
         },
         {
@@ -1327,6 +1330,40 @@
               "match": "\"",
               "name": "invalid.illegal.nim"
             },
+            {
+              "include": "#string_escapes"
+            },
+            {
+              "include": "#fmt_interpolation"
+            }
+          ]
+        }
+      ]
+    },
+    "fmt_string_call_triple": {
+      "begin": "(fmt)\\((?=\"\"\")",
+      "beginCaptures": {
+        "1": {
+          "name": "support.function.any-method.nim"
+        }
+      },
+      "end": "\\)",
+      "patterns": [
+        {
+          "begin": "\"\"\"",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.nim"
+            }
+          },
+          "end": "\"\"\"(?=\\))",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.nim"
+            }
+          },
+          "name": "string.quoted.triple.nim",
+          "patterns": [
             {
               "include": "#string_escapes"
             },

--- a/syntaxes/nim.json
+++ b/syntaxes/nim.json
@@ -1479,6 +1479,18 @@
     "custom_literal": {
       "patterns": [
         {
+          "match": "-?(\\b0[xX](\\h[_\\h]*)(\\.[_\\d]+)?')(?!((([iIuU](8|16|32|64))|[uU][^a-zA-Z0-9])|([fF](32|64|128)|[fFdD][^a-zA-Z0-9])))([a-zA-Z]\\w*)",
+          "name": "constant.numeric.custom.lit.hexadecimal.nim"
+        },
+        {
+          "match": "-?(\\b0o([0-7][_0-7]*)(\\.[_\\d]+)?')(?!((([iIuU](8|16|32|64))|[uU][^a-zA-Z0-9])|([fF](32|64|128)|[fFdD][^a-zA-Z0-9])))([a-zA-Z]\\w*)",
+          "name": "constant.numeric.custom.lit.octal.nim"
+        },
+        {
+          "match": "-?(\\b0(b|B)([01][_01]*)(\\.[_\\d]+)?')(?!((([iIuU](8|16|32|64))|[uU][^a-zA-Z0-9])|([fF](32|64|128)|[fFdD][^a-zA-Z0-9])))([a-zA-Z]\\w*)",
+          "name": "constant.numeric.custom.lit.binary.nim"
+        },
+        {
           "match": "-?(\\b(\\d[_\\d]*)(\\.[_\\d]+)?')(?!((([iIuU](8|16|32|64))|[uU][^a-zA-Z0-9])|([fF](32|64|128)|[fFdD][^a-zA-Z0-9])))([a-zA-Z]\\w*)",
           "name": "constant.numeric.custom.lit.nim"
         }


### PR DESCRIPTION
This fixes incorrect highlighting of custom hexadecimal, octal and binary literals. For example, `0x0123'bi` is not highlighted properly:

![Hexadecimal literal not highlighted correctly](https://github.com/saem/vscode-nim/assets/575909/71034810-81eb-4619-8762-df474c8c510f)

I also fixed #122 (incorrect highlight when `fmt` is used as function with triple quoted strings):

![Triple quoted literal inside fmt function not highlighted correctly](https://github.com/saem/vscode-nim/assets/575909/3223ff95-6273-43cb-81e8-95d13e306e1f)
